### PR TITLE
Create popup from meta field

### DIFF
--- a/db.json
+++ b/db.json
@@ -24,15 +24,24 @@
         "application": "Sensor",
         "types": [
           {
-            "name": "Luchtkwaliteit",
-            "application": "Luchtkwaliteit",
+            "name": "People",
+            "application": "Cats",
+            "description": ""
+          },
+          {
+            "name": "Cats",
+            "application": "Cats",
             "description": ""
           }
         ],
         "categories": ["Sensor"],
-        "longitude": 3.7046588,
-        "latitude": 51.0509617,
-        "organisation": "Jef's house"
+        "longitude": 3.70557,
+        "latitude": 51.0507,
+        "organisation": "Jef's house",
+        "meta": {
+          "data processing": "A cat will sense the presence of people or other cats and will use this information to purr dramatically loud.",
+          "what is this?": "CAAS - Cat as a sensor"
+        }
       },
       {
         "_links": {

--- a/src/components/LeafletMarker/index.js
+++ b/src/components/LeafletMarker/index.js
@@ -6,11 +6,26 @@ import { injectIntl, intlShape } from 'react-intl';
 import categories from '../../static/categories';
 import './style.scss';
 import messages from './messages';
+import LPopupMetaInfo from '../LeafletPopupMetaInfo';
 
 
 const createIcon = (device) => new L.Icon({
   ...(categories[device.application] || categories.Sensor)
 });
+
+const createMetaInfoFields = (device) => {
+  if (!device.meta) return [];
+
+  return Object.entries(device.meta).map(([metaFieldKey, metaFieldValue]) => (
+    <LPopupMetaInfo
+      key={metaFieldKey}
+      field={{
+        title: metaFieldKey,
+        value: metaFieldValue
+      }}
+    ></LPopupMetaInfo>
+  ));
+};
 
 const LMarker = (props) => {
   const device = props.device;
@@ -35,6 +50,7 @@ const LMarker = (props) => {
             <p className="device-popup-information-label">{typesLabel}</p>
             <p className="device-popup-information-text">{device.types.map((el) => el.name).join(', ') || 'Unknown'}</p>
           </div>
+          {createMetaInfoFields(device)}
         </div>
       </Popup>
     </Marker>
@@ -49,7 +65,8 @@ LMarker.propTypes = {
       name: PropTypes.string.isRequired
     })),
     categories: PropTypes.arrayOf(PropTypes.string),
-    id: PropTypes.number
+    id: PropTypes.number,
+    meta: PropTypes.object
   }).isRequired,
   intl: intlShape.isRequired,
 };

--- a/src/components/LeafletMarker/style.scss
+++ b/src/components/LeafletMarker/style.scss
@@ -1,5 +1,6 @@
 .leaflet-popup-content {
   margin: 0;
+  width: unset;
   .device-popup {
     display: flex;
     flex-direction: column;

--- a/src/components/LeafletPopupMetaInfo/index.js
+++ b/src/components/LeafletPopupMetaInfo/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './style.scss';
+
+const capitalize = (word) => word[0].toUpperCase() + word.substring(1, word.length);
+const capitalizeAll = (words) => words.split(' ').map((word) => capitalize(word)).join(' ');
+
+
+const LPopupMetaInfo = (props) => {
+  const field = props.field;
+  return (
+    <div className="device-popup-information">
+      <p className="device-popup-information-label">{capitalizeAll(field.title)}</p>
+      <p className="device-popup-information-text">{field.value}</p>
+    </div>
+  );
+};
+
+LPopupMetaInfo.propTypes = {
+  field: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  }).isRequired
+};
+export default LPopupMetaInfo;

--- a/src/components/LeafletPopupMetaInfo/style.scss
+++ b/src/components/LeafletPopupMetaInfo/style.scss
@@ -1,0 +1,24 @@
+.device-popup-information {
+  padding: 0.5rem;
+  p {
+    margin: 0;
+    line-height: 1.4;
+  }
+  &-label {
+    padding: 0;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 16px;
+    color: #999;
+    border: none;
+    box-shadow: none;
+  }
+  &-text {
+    padding: 4px 0 0;
+    font-size: 16px;
+    line-height: 1;
+    color: #333;
+    border: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
This pull request allows for extra info to be collected for devices. Every device can have a "meta" field which will be displayed on the Marker Popup on the Map.